### PR TITLE
Update Rules::Discount and Rules::BulkDiscount

### DIFF
--- a/lib/checkout.rb
+++ b/lib/checkout.rb
@@ -23,7 +23,7 @@ class Checkout
     total = @basket.sum(&:price)
 
     @rules.each do |rule|
-      rule = rule.new(@basket)
+      rule = rule.new(@basket, total)
 
       total -= rule.discount
     end

--- a/lib/rules/bulk_discount.rb
+++ b/lib/rules/bulk_discount.rb
@@ -5,7 +5,7 @@ module Rules
     ELIGIBLE_ITEM_CODE = 001
     PRICE_REDUCTION = 0.75
 
-    def initialize(basket)
+    def initialize(basket, _total)
       @basket = basket
     end
 

--- a/lib/rules/discount.rb
+++ b/lib/rules/discount.rb
@@ -5,24 +5,19 @@ module Rules
     TEN_PERCENT = 0.10
     MINIMUM_SPENT = 60
 
-    def initialize(basket)
+    def initialize(basket, total)
       @basket = basket
+      @total = total
     end
 
     def eligible?
-      total > MINIMUM_SPENT
+      @total > MINIMUM_SPENT
     end
 
     def discount
       return 0 unless eligible?
 
-      (total * TEN_PERCENT)
-    end
-
-    private
-
-    def total
-      @basket.sum(&:price)
+      (@total * TEN_PERCENT)
     end
   end
 end

--- a/spec/lib/checkout_spec.rb
+++ b/spec/lib/checkout_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe Checkout do
       let(:subject) { described_class.new(rules) }
       let(:rules) do
         [
-          Rules::Discount,
           Rules::BulkDiscount,
+          Rules::Discount,
         ]
       end
 
@@ -67,9 +67,7 @@ RSpec.describe Checkout do
         subject.scan(001)
         subject.scan(003)
 
-        # total - 10%   - bulk
-        # 83.45 - 8.345 - 1.50 = 73.605
-        expect(subject.total).to eq(73.61)
+        expect(subject.total).to eq(73.76)
       end
     end
   end

--- a/spec/lib/rules/bulk_discount_spec.rb
+++ b/spec/lib/rules/bulk_discount_spec.rb
@@ -3,7 +3,7 @@ require './lib/rules/bulk_discount'
 
 module Rules
   RSpec.describe BulkDiscount do
-    subject { described_class.new(basket) }
+    subject { described_class.new(basket, nil) }
     let(:basket) { [] }
 
     describe '#eligible?' do

--- a/spec/lib/rules/discount_spec.rb
+++ b/spec/lib/rules/discount_spec.rb
@@ -3,8 +3,9 @@ require './lib/rules/discount'
 
 module Rules
   RSpec.describe Discount do
-    subject { described_class.new(basket) }
+    subject { described_class.new(basket, total) }
     let(:basket) { [] }
+    let(:total) { basket.sum(&:price) }
 
     describe '#eligible?' do
       context 'when basket is empty' do


### PR DESCRIPTION
I have made corrections, due to an interpretation mistake.

The code was applying the discount to the summed price of all product 
and then removed the bulk discount. 

This is wrong because in a real-life scenario a product discount is applied immediately to the product and then any percentage discounts are applied at the end.

There was a significant difference of 15p.

This commit fixes that mistake and maintains the signature of each Rule 
class.

## Describe your changes

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have added thorough tests.
