### PR TITLE
Add buy one get one free

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,14 @@ Our client is an online marketplace, here is a sample of some of the products av
 | 001           | Lavender heart         | £9.25      |
 | 002           | Personalised cufflinks | £45.00     |
 | 003           | Kids T-shirt           | £19.95     |
+| 004           | Coffee                 | £11.23     |
 
 
 Our marketing team want to offer promotions as an incentive for our customers to purchase these items.
 
-If you spend over £60, then you get 10% of your purchase
-If you buy 2 or more lavender hearts then the price drops to £8.50.
+- When people spend over £60, they get 10% of the whole purchase.
+- When people buy 2 or more lavender hearts then the price drops to £8.50.
+- When people buy 2 coffees, they get one for free.
 
 Our check-out can scan items in any order, and because our promotions will change, it needs to be flexible regarding our promotional rules.
 
@@ -42,6 +44,12 @@ Total price expected: £36.95
 
 Basket: 001,002,001,003
 Total price expected: £73.76
+
+Basket: 004,004
+Total price expected: £11.23
+
+Basket: 001,002,001,004,003,004
+Total price expected: £83.86
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ $ irb -r ./lib/checkout.rb
 
 ```ruby
 rules = [
-  Rules::BulkDiscount.new(item: ItemStorage.find(001), minimum_quantity: 2, price_reduction: 0.75), 
+  Rules::BulkDiscount.new(item: ItemStorage.find(001), minimum_quantity: 2, price_reduction: 0.75),
   Rules::Discount.new(percentage: 0.10, minimum_spent: 60)
 ]
 
@@ -82,7 +82,7 @@ checkout.total
 
 ```ruby
 rules = [
-  Rules::BulkDiscount.new(item: ItemStorage.find(001), minimum_quantity: 2, price_reduction: 0.75), 
+  Rules::BulkDiscount.new(item: ItemStorage.find(001), minimum_quantity: 2, price_reduction: 0.75),
   Rules::Discount.new(percentage: 0.10, minimum_spent: 60)
 ]
 
@@ -101,7 +101,7 @@ checkout.total
 
 ```ruby
 rules = [
-  Rules::BulkDiscount.new(item: ItemStorage.find(001), minimum_quantity: 2, price_reduction: 0.75), 
+  Rules::BulkDiscount.new(item: ItemStorage.find(001), minimum_quantity: 2, price_reduction: 0.75),
   Rules::Discount.new(percentage: 0.10, minimum_spent: 60)
 ]
 
@@ -115,6 +115,29 @@ checkout.scan(003)
 checkout.total
 
 => 73.76
+```
+
+### Test data 4
+
+```ruby
+rules = [
+  Rules::BulkDiscount.new(item: ItemStorage.find(001), minimum_quantity: 2, price_reduction: 0.75),
+  Rules::Discount.new(percentage: 0.10, minimum_spent: 60),
+  Rules::BuyOneGetOneFree.new(item: ItemStorage.find(004), minimum_quantity: 2)
+]
+
+checkout = Checkout.new(rules)
+
+subject.scan(001)
+subject.scan(002)
+subject.scan(001)
+subject.scan(004)
+subject.scan(003)
+subject.scan(004)
+
+checkout.total
+
+=> 83.86
 ```
 
 

--- a/lib/checkout.rb
+++ b/lib/checkout.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 require_relative 'rules/bulk_discount'
+require_relative 'rules/buy_one_get_one_free'
 require_relative 'rules/discount'
 require_relative 'item_storage'
 
 class Checkout
   def initialize(rules = [])
-    @rules = rules
+    @rules = reorder_rules(rules)
     @basket = []
   end
 
@@ -26,5 +27,19 @@ class Checkout
     end
 
     total.round(2)
+  end
+
+  private
+
+  # Make sure that Rules::Discount is applied at the very end
+  # This gives opportunity for all other discounts to be applied
+  # Which means that a overall percentage discount is applied at the end.
+  def reorder_rules(rules)
+    return [] if rules.empty?
+    return rules unless rules.map(&:class).include?(Rules::Discount)
+
+    discount_rule_index = rules.map(&:class).index(Rules::Discount)
+    discount_rule = rules.delete_at(discount_rule_index)
+    rules.append(discount_rule)
   end
 end

--- a/lib/item_storage.rb
+++ b/lib/item_storage.rb
@@ -14,7 +14,8 @@ class ItemStorage
       @storage ||= [
         Item.new(code: 001, name: 'Lavender heart ', price: 9.25),
         Item.new(code: 002, name: 'Personalised cufflinks', price: 45.00),
-        Item.new(code: 003, name: 'Kids T-shirt', price: 19.95)
+        Item.new(code: 003, name: 'Kids T-shirt', price: 19.95),
+        Item.new(code: 004, name: 'Coffee', price: 11.23)
       ]
     end
   end

--- a/lib/rules/buy_one_get_one_free.rb
+++ b/lib/rules/buy_one_get_one_free.rb
@@ -1,17 +1,16 @@
 # frozen_string_literal: true
 
 module Rules
-  class BulkDiscount
-    def initialize(item:, minimum_quantity:, price_reduction:)
+  class BuyOneGetOneFree
+    def initialize(item:, minimum_quantity:)
       @item = item
       @minimum_quantity = minimum_quantity
-      @price_reduction = price_reduction
     end
 
     def discount(basket, _total)
       return 0 unless eligible?(basket)
 
-      count_eligible_item(basket) * @price_reduction
+      (count_eligible_item(basket) / @minimum_quantity) * @item.price
     end
 
     private

--- a/spec/lib/checkout_spec.rb
+++ b/spec/lib/checkout_spec.rb
@@ -81,6 +81,30 @@ RSpec.describe Checkout do
 
         expect(subject.total).to eq(73.76)
       end
+
+      context 'and there is a new pricing rule for coffee' do
+        let(:buy_one_get_one_free_rule) do
+          Rules::BuyOneGetOneFree.new(
+            item: ItemStorage.find(004),
+            minimum_quantity: 2
+          )
+        end
+
+        let(:rules) do
+          super().append(buy_one_get_one_free_rule)
+        end
+
+        it 'calculates the total with bulk discount, 10% discount and buy-one-get-one-free' do
+          subject.scan(001)
+          subject.scan(002)
+          subject.scan(001)
+          subject.scan(004)
+          subject.scan(003)
+          subject.scan(004)
+
+          expect(subject.total).to eq(83.86)
+        end
+      end
     end
   end
 end

--- a/spec/lib/rules/buy_one_get_one_free_spec.rb
+++ b/spec/lib/rules/buy_one_get_one_free_spec.rb
@@ -1,0 +1,62 @@
+require 'item_storage'
+require './lib/rules/buy_one_get_one_free'
+
+module Rules
+  RSpec.describe BuyOneGetOneFree do
+    let(:item) { ItemStorage.find(004) }
+    let(:minimum_quantity) { 2 }
+
+    subject do
+      described_class.new(
+        item: item,
+        minimum_quantity: minimum_quantity
+      )
+    end
+
+    describe '#discount' do
+      let(:basket) { [item, item] }
+
+      it 'returns the value to be discounted' do
+        expect(
+          subject.discount(basket, nil)
+        ).to eq(11.23)
+      end
+
+      context 'when basket has multiples of minimum quantity' do
+        let(:basket) { super().append(item, item) }
+
+        it 'returns the value to be discounted' do
+          expect(
+            subject.discount(basket, nil)
+          ).to eq(22.46)
+        end
+      end
+
+      context 'when there are 3 of the eligible item' do
+        let(:basket) { super().append(item) }
+
+        it 'returns the value to be discounted' do
+          expect(
+            subject.discount(basket, nil)
+          ).to eq(11.23)
+        end
+      end
+
+      context 'when only one eligible item' do
+        let(:basket) { [item] }
+
+        it 'returns zero' do
+          expect(subject.discount(basket, nil)).to eq(0)
+        end
+      end
+
+      context 'when basket is empty' do
+        let(:basket) { [] }
+
+        it 'returns zero' do
+          expect(subject.discount(basket, nil)).to eq(0)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Describe your changes

I decided to have some fun and add a new rule to the code challenge.

This rule allows people to buy an item and get a second item for free. 
It considers multiples of the minimum quantity to apply that discount.

### Example
The minimum quantity for coffee is 2 (where one is free), but when a person buys 4 (a multiple of 2, then two are free). 
When it's only 3, only one coffee will be free.

### Rules::Discount

In commit 79b5d76eef5259b18c046da670b2b880d20398d7 I have introduced logic to move the Rules::Discount to the end of the array of rules. The reason for this is that in a real case scenario, an overall discount is applied at the very end. This way the code is more forgiven on the order that the rules are inserted in a given `Checkout` instance.

In the future, I would think of dealing with multiple `Rules::Discount` given to the same `Checkout` instance, I believe the best is to raise an error when more than one `Rules::Discount` is given as it is impossible to decide which one is the best to keep.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have added thorough tests.
